### PR TITLE
chore(renovate): update config

### DIFF
--- a/default.json
+++ b/default.json
@@ -1,5 +1,12 @@
 {
-  "extends": ["config:base", "config:recommended", ":prHourlyLimitNone", ":timezone(Asia/Tokyo)"],
+  "extends": [
+    "config:base",
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    ":prHourlyLimitNone",
+    ":timezone(Asia/Tokyo)"
+  ],
   "labels": ["dependencies", "renovate"],
   "dependencyDashboard": true,
   "automergeStrategy": "squash",


### PR DESCRIPTION
- Semantic Commit messages を有効化
- Commit prefix を `chore(deps)` に設定